### PR TITLE
feat(api): add JSON HTTP encoder/decoder helper methods

### DIFF
--- a/http/decoder.go
+++ b/http/decoder.go
@@ -1,0 +1,25 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+)
+
+// GetJSONContent returns the JSON unmarshalled content of a http.Request
+func GetJSONContent(v interface{}, r *http.Request) error {
+	if r == nil && r.Body == nil {
+		return errors.New("cannot get content out of a nil response or body")
+	}
+
+	// try to decode body
+	err := json.NewDecoder(r.Body).Decode(v)
+	if err != nil {
+		return err
+	}
+
+	// close body
+	defer r.Body.Close()
+
+	return nil
+}

--- a/http/decoder_test.go
+++ b/http/decoder_test.go
@@ -1,0 +1,40 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+)
+
+func TestGetJSONContent(t *testing.T) {
+
+	// struct to marshall
+	customError := RESTError{
+		"myCustomErrorMessage",
+	}
+
+	// json marshalling struct
+	content, err := json.Marshal(&customError)
+	if err != nil {
+		t.Errorf("failed to marshall struct as a JSON body, %v", err)
+	}
+	reader := bytes.NewReader(content)
+
+	// building new request
+	request, err := http.NewRequest(http.MethodPost, "localhost:8020", reader)
+	if err != nil {
+		t.Errorf("failed to build test resquest, %v", err)
+	}
+
+	customErrorRsp := RESTError{}
+	err = GetJSONContent(&customErrorRsp, request)
+	if err != nil {
+		t.Errorf("failed to unmarshall request body, %v", err)
+	}
+
+	if customError != customErrorRsp {
+		t.Errorf("Expected body %v is different from decoded one %v", customError, customErrorRsp)
+	}
+
+}

--- a/http/encoder.go
+++ b/http/encoder.go
@@ -1,0 +1,68 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// RESTError is used to send back an error as a JSON message over HTTP connection
+type RESTError struct {
+	Error string `json:"error"`
+}
+
+// MediaType is used to declare a specific content-type
+type MediaType string
+
+const (
+	// TypeJSONUTF8 is media type used for UTF-8 JSON content
+	TypeJSONUTF8 MediaType = "application/json; charset=UTF-8"
+)
+
+// String returns a string representation of a MediaType
+func (m MediaType) String() string {
+	return string(m)
+}
+
+const (
+	// HeaderContentType is the key used for response content type
+	HeaderContentType = "Content-Type"
+
+	// Error messages
+	resourceNotFoundMsg = "resource not found"
+	errorMsg            = "error"
+)
+
+// SendJSONWithHTTPCode outputs JSON RESTError through a http.ResponseWriter with a given HTTP code
+func SendJSONWithHTTPCode(w http.ResponseWriter, d interface{}, code int) error {
+	w.Header().Set(HeaderContentType, TypeJSONUTF8.String())
+	w.WriteHeader(code)
+	if d != nil {
+		err := json.NewEncoder(w).Encode(d)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SendJSONOk outputs JSON RESTError through a http.ResponseWriter with http.StatusOK code
+func SendJSONOk(w http.ResponseWriter, d interface{}) {
+	SendJSONWithHTTPCode(w, d, http.StatusOK)
+}
+
+// SendJSONError sends an JSON RESTError error through a http.ResponseWriter with a custom message and error code
+func SendJSONError(w http.ResponseWriter, error string, code int) {
+	SendJSONWithHTTPCode(w, map[string]string{errorMsg: error}, code)
+}
+
+// SendJSONNotFound sends an JSON RESTError error through a http.ResponseWriter with a "Resource not found" message
+func SendJSONNotFound(w http.ResponseWriter) {
+	SendJSONError(w, resourceNotFoundMsg, http.StatusNotFound)
+}
+
+// NotFoundHandler returns an http.HandlerFunc with a JSON answer implementation
+func NotFoundHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		SendJSONNotFound(w)
+	}
+}

--- a/http/encoder_test.go
+++ b/http/encoder_test.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestSendJSONWithHTTPCode test sending struct as JSON bodies
+func TestSendJSONWithHTTPCode(t *testing.T) {
+	// build a response recorder
+	response := httptest.NewRecorder()
+	customError := RESTError{
+		"myCustomErrorMessage",
+	}
+
+	// send JSON body
+	err := SendJSONWithHTTPCode(response, customError, http.StatusOK)
+	if err != nil {
+		t.Errorf("failed to send successfuly a struct as a JSON body, %v", err)
+	}
+
+	if http.StatusOK != response.Code {
+		t.Errorf("Expected response code %d is different from decoded one %d", http.StatusOK, response.Code)
+	}
+
+	customErrorRsp := RESTError{}
+	err = json.NewDecoder(response.Body).Decode(&customErrorRsp)
+	if err != nil {
+		t.Errorf("failed to unmarshall response body, %v", err)
+	}
+
+	if customError != customErrorRsp {
+		t.Errorf("Expected body %v is different from decoded one %v", customError, customErrorRsp)
+	}
+
+}


### PR DESCRIPTION
Hello,

First attempt to add some JSON over HTTP encoding/decoding helper methods.
Package name and content to be discussed and adjusted.

At least when building JSON REST API, you need such methods a lot to handle your endpoints content.